### PR TITLE
Remove hardcoded identifiers

### DIFF
--- a/LightService.cpp
+++ b/LightService.cpp
@@ -736,6 +736,7 @@ void lightsNewFn(WcFnRequestHandler *handler, String requestUri, HTTPMethod meth
 void LightServiceClass::begin() {
   begin(new ESP8266WebServer(80));
 }
+
 void LightServiceClass::begin(ESP8266WebServer *svr) {
   HTTP = svr;
   macString = String(WiFi.macAddress());
@@ -755,6 +756,7 @@ void LightServiceClass::begin(ESP8266WebServer *svr) {
   on(configFn, "/api/*/config", HTTP_ANY);
   on(configFn, "/api/config", HTTP_GET);
   on(wholeConfigFn, "/api/*", HTTP_GET);
+  on(wholeConfigFn, "/api/", HTTP_GET);
   on(authFn, "/api", HTTP_POST);
   on(unimpFn, "/api/*/schedules", HTTP_GET);
   on(unimpFn, "/api/*/rules", HTTP_GET);
@@ -927,6 +929,7 @@ bool parseHueLightInfo(HueLightInfo currentInfo, aJsonObject *parsedRoot, HueLig
       newInfo->effect = EFFECT_NONE;
     }
   }
+  
   // pull alert
   aJsonObject* alertState = aJson.getObjectItem(parsedRoot, "alert");
   if (alertState) {
@@ -938,6 +941,12 @@ bool parseHueLightInfo(HueLightInfo currentInfo, aJsonObject *parsedRoot, HueLig
     } else {
       newInfo->alert = ALERT_NONE;
     }
+  }
+
+  // pull transitiontime
+  aJsonObject* transitiontimeState = aJson.getObjectItem(parsedRoot, "transitiontime");
+  if (transitiontimeState) {
+    newInfo->transitionTime = transitiontimeState->valueint;
   }
 
   aJsonObject* hueState = aJson.getObjectItem(parsedRoot, "hue");

--- a/LightService.cpp
+++ b/LightService.cpp
@@ -268,7 +268,7 @@ int ssdpMsgFormatCallback(SSDPClass *ssdp, char *buffer, int buff_len,
       interval,
       ipString.c_str(), port, schemaURL,
       modelName, modelNumber,
-      "001788FFFE142F92",
+      bridgeIDString.c_str(),
       deviceType,
       uuid);
   }
@@ -345,7 +345,7 @@ void on(HandlerFunction fn, const String &wcUri, HTTPMethod method, char wildcar
 }
 
 void descriptionFn() {
-  String str = "<root><specVersion><major>1</major><minor>0</minor></specVersion><URLBase>http://" + ipString + ":80/</URLBase><device><deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType><friendlyName>Philips hue (" + ipString + ")</friendlyName><manufacturer>Royal Philips Electronics</manufacturer><manufacturerURL>http://www.philips.com</manufacturerURL><modelDescription>Philips hue Personal Wireless Lighting</modelDescription><modelName>Philips hue bridge 2012</modelName><modelNumber>929000226503</modelNumber><modelURL>http://www.meethue.com</modelURL><serialNumber>00178817122c</serialNumber><UDN>uuid:2f402f80-da50-11e1-9b23-00178817122c</UDN><presentationURL>index.html</presentationURL><iconList><icon><mimetype>image/png</mimetype><height>48</height><width>48</width><depth>24</depth><url>hue_logo_0.png</url></icon><icon><mimetype>image/png</mimetype><height>120</height><width>120</width><depth>24</depth><url>hue_logo_3.png</url></icon></iconList></device></root>";
+  String str = "<root><specVersion><major>1</major><minor>0</minor></specVersion><URLBase>http://" + ipString + ":80/</URLBase><device><deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType><friendlyName>Philips hue (" + ipString + ")</friendlyName><manufacturer>Royal Philips Electronics</manufacturer><manufacturerURL>http://www.philips.com</manufacturerURL><modelDescription>Philips hue Personal Wireless Lighting</modelDescription><modelName>Philips hue bridge 2012</modelName><modelNumber>929000226503</modelNumber><modelURL>http://www.meethue.com</modelURL><serialNumber>"+macString+"</serialNumber><UDN>uuid:2f402f80-da50-11e1-9b23-"+macString+"</UDN><presentationURL>index.html</presentationURL><iconList><icon><mimetype>image/png</mimetype><height>48</height><width>48</width><depth>24</depth><url>hue_logo_0.png</url></icon><icon><mimetype>image/png</mimetype><height>120</height><width>120</width><depth>24</depth><url>hue_logo_3.png</url></icon></iconList></device></root>";
   HTTP->send(200, "text/plain", str);
   Serial.println(str);
 }
@@ -778,7 +778,7 @@ void LightServiceClass::begin(ESP8266WebServer *svr) {
   SSDP.setSchemaURL((char*)"description.xml");
   SSDP.setHTTPPort(80);
   SSDP.setName((char*)"Philips hue clone");
-  SSDP.setSerialNumber((char*)"001788102201");
+  SSDP.setSerialNumber(macString.c_str());
   SSDP.setURL((char*)"index.html");
   SSDP.setModelName((char*)"IpBridge");
   SSDP.setModelNumber((char*)"0.1");


### PR DESCRIPTION
This allows more Hue apps to autodiscover and interoperate properly with
the emulated bridge.